### PR TITLE
uninitialized constant Rails::Generators::Actions (NameError)

### DIFF
--- a/lib/generators/harness_gems/harness_gems_generator.rb
+++ b/lib/generators/harness_gems/harness_gems_generator.rb
@@ -1,3 +1,4 @@
+require 'rails/generators'
 require 'rails/generators/base'
 
 class HarnessGemsGenerator < Rails::Generators::Base


### PR DESCRIPTION
When trying to run the generator in Rails 4.1, I'm getting this error:

```
$ rails generate spec_harness --no-gems --no-guardfile
/Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/railties-4.1.1/lib/rails/generators/base.rb:17:in `<class:Base>': uninitialized constant Rails::Generators::Actions (NameError)
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/railties-4.1.1/lib/rails/generators/base.rb:15:in `<module:Generators>'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/railties-4.1.1/lib/rails/generators/base.rb:11:in `<module:Rails>'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/railties-4.1.1/lib/rails/generators/base.rb:10:in `<top (required)>'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/rails_spec_harness-0.0.8/lib/generators/harness_gems/harness_gems_generator.rb:1:in `require'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/rails_spec_harness-0.0.8/lib/generators/harness_gems/harness_gems_generator.rb:1:in `<top (required)>'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/rails_spec_harness-0.0.8/lib/rails_spec_harness.rb:2:in `require'
    from /Volumes/Laurel/Users/daviscabral/.rvm/gems/ruby-2.1.1/gems/rails_spec_harness-0.0.8/lib/rails_spec_harness.rb:2:in `<top (required)>'
```

I was able to fix it adding `require 'rails/generators'` in the first line of `HarnessGemsGenerator` class.
